### PR TITLE
1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,44 +1,9 @@
 {
-  "_from": "cordova-plugin-ionic-webview-openblank",
-  "_id": "cordova-plugin-ionic-webview-openblank@0.2.0",
-  "_inBundle": false,
-  "_integrity": "sha512-s0iSkW1IdJ0rY2vN/R7qXCzpICR9nPnW66hYv9FqiyH80fNj0u+eKsG+qVnNFvA5lYYcAVzJaNW4w6kgklEDKg==",
-  "_location": "/cordova-plugin-ionic-webview-openblank",
-  "_phantomChildren": {},
-  "_requested": {
-    "type": "tag",
-    "registry": true,
-    "raw": "cordova-plugin-ionic-webview-openblank",
-    "name": "cordova-plugin-ionic-webview-openblank",
-    "escapedName": "cordova-plugin-ionic-webview-openblank",
-    "rawSpec": "",
-    "saveSpec": null,
-    "fetchSpec": "latest"
-  },
-  "_requiredBy": [
-    "#USER",
-    "/"
-  ],
-  "_resolved": "https://registry.npmjs.org/cordova-plugin-ionic-webview-openblank/-/cordova-plugin-ionic-webview-openblank-0.2.0.tgz",
-  "_shasum": "6e216b3ace560bb7e6f6281390ea0a4859627883",
-  "_spec": "cordova-plugin-ionic-webview-openblank",
-  "_where": "/Users/Youssef/Documents/workspaces/ts-mob/node_modules",
   "author": {
-    "name": "Youssef Makboul"
+    "name": "Transfermarkt"
   },
-  "bugs": {
-    "url": "https://github.com/youssmak/cordova-plugin-ionic-webview-openblank/issues"
-  },
-  "bundleDependencies": false,
-  "cordova": {
-    "id": "cordova-plugin-ionic-webview-openblank",
-    "platforms": [
-      "ios"
-    ]
-  },
-  "deprecated": false,
   "description": "Cordova WKWebView OpenBlank Plugin",
-  "homepage": "https://github.com/youssmak/cordova-plugin-ionic-webview-openblank#readme",
+  "homepage": "https://github.com/transfermarkt/cordova-plugin-ionic-webview-openblank#readme",
   "keywords": [
     "cordova",
     "wkwebview",
@@ -51,9 +16,5 @@
   ],
   "license": "Apache 2.0",
   "name": "cordova-plugin-ionic-webview-openblank",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/youssmak/cordova-plugin-ionic-webview-openblank.git"
-  },
-  "version": "0.2.0"
+  "platforms": ["ios"]
 }

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" id="cordova-plugin-ionic-webview-openblank" version="0.2.0">
+<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" id="cordova-plugin-ionic-webview-openblank" version="1.0.0">
     <name>OpenBlank</name>
     <description>Cordova WKWebView OpenBlank Plugin</description>
     <license>Apache 2.0</license>

--- a/src/ios/CDVWKWebViewUIDelegate+OpenBlank.m
+++ b/src/ios/CDVWKWebViewUIDelegate+OpenBlank.m
@@ -14,7 +14,11 @@
       NSURL *url = [[navigationAction request] URL];
       UIApplication *application = [UIApplication sharedApplication];
       if ([application canOpenURL:url]) {
-        [application openURL:url];
+        if (@available(iOS 10.0, *)) {
+          [application openURL:url options:@{} completionHandler:nil];
+        } else {
+          [application openURL:url];
+        }
       }
     }
     return nil;


### PR DESCRIPTION
Update deprecated openURL Method:

BUG IN CLIENT OF UIKIT: The caller of UIApplication.openURL(_:) needs to migrate to the non-deprecated UIApplication.open(_:options:completionHandler:). Force returning false (NO).